### PR TITLE
Improve widget embed size handling for Notion integration

### DIFF
--- a/app/widget/[id]/WidgetDisplay.tsx
+++ b/app/widget/[id]/WidgetDisplay.tsx
@@ -12,29 +12,50 @@ interface WidgetDisplayProps {
 export default function WidgetDisplay({ widgetId }: WidgetDisplayProps) {
   const systemTheme = useSystemTheme();
   const [locale, setLocale] = useState(getLocale());
-  
+  const [isEmbedded, setIsEmbedded] = useState(false);
+
   useEffect(() => {
     setLocale(getLocale());
+
+    // Check if we're embedded in an iframe (Notion)
+    try {
+      setIsEmbedded(window !== window.parent);
+    } catch {
+      setIsEmbedded(false);
+    }
   }, []);
-  
+
   const widget = widgets.find(w => w.id === widgetId);
-  
+
   if (!widget) {
     return null;
   }
 
   const WidgetComponent = widget.component;
 
+  // When embedded (Notion), use 100% to fit the iframe
+  // When standalone (web), use the widget's defaultSize
+  const containerStyle = isEmbedded ? {
+    width: '100%',
+    height: '100%',
+  } : {
+    width: `${widget.defaultSize.width}px`,
+    height: `${widget.defaultSize.height}px`,
+    maxWidth: '100vw',
+    maxHeight: '100vh',
+  };
+
   return (
-    <div 
-      style={{ 
-        width: '100%',
-        height: '100%',
+    <div
+      style={{
+        ...containerStyle,
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
         backgroundColor: systemTheme.colors.background,
         transition: 'background-color 0.3s ease',
+        margin: isEmbedded ? '0' : 'auto',
+        position: isEmbedded ? 'static' : 'relative',
       }}
     >
       <WidgetComponent theme={systemTheme} locale={locale} notion={widget.notion} />

--- a/components/widgets/Calendar.tsx
+++ b/components/widgets/Calendar.tsx
@@ -70,9 +70,9 @@ export function Calendar({ theme, locale = 'en', notion }: CalendarProps) {
     <WidgetContainer theme={theme} notion={notion}>
       <div style={{
         width: '100%',
-        maxWidth: '400px',
+        maxWidth: '100%',
         margin: '0 auto',
-        padding: '24px',
+        padding: '8px',
       }}>
         {/* Header */}
         <div style={{

--- a/components/widgets/Countdown.tsx
+++ b/components/widgets/Countdown.tsx
@@ -121,9 +121,9 @@ export function Countdown({ theme, locale = 'en', notion }: CountdownProps) {
     <WidgetContainer theme={theme} notion={notion}>
       <div style={{
         width: '100%',
-        maxWidth: '500px',
+        maxWidth: '100%',
         margin: '0 auto',
-        padding: '24px',
+        padding: '8px',
         textAlign: 'center',
       }}>
         {/* Target title */}

--- a/components/widgets/Quote.tsx
+++ b/components/widgets/Quote.tsx
@@ -56,9 +56,9 @@ export function Quote({ theme, locale = 'en', notion }: QuoteProps) {
     <WidgetContainer theme={theme} notion={notion}>
       <div style={{
         width: '100%',
-        maxWidth: '600px',
+        maxWidth: '100%',
         margin: '0 auto',
-        padding: '32px',
+        padding: '12px',
         textAlign: 'center',
         position: 'relative',
       }}>

--- a/components/widgets/WidgetContainer.tsx
+++ b/components/widgets/WidgetContainer.tsx
@@ -25,7 +25,7 @@ export function WidgetContainer({ children, theme, notion }: WidgetContainerProp
       // In some security contexts, accessing window.parent throws an error
       setIsEmbedded(false);
     }
-    
+
     const updateDimensions = () => {
       setDimensions({
         width: window.innerWidth,
@@ -35,7 +35,7 @@ export function WidgetContainer({ children, theme, notion }: WidgetContainerProp
 
     updateDimensions();
     window.addEventListener('resize', updateDimensions);
-    
+
     // Use ResizeObserver for better height detection
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
@@ -43,9 +43,9 @@ export function WidgetContainer({ children, theme, notion }: WidgetContainerProp
         setDimensions(prev => ({ ...prev, height }));
       }
     });
-    
+
     resizeObserver.observe(document.body);
-    
+
     return () => {
       window.removeEventListener('resize', updateDimensions);
       resizeObserver.disconnect();
@@ -65,7 +65,9 @@ export function WidgetContainer({ children, theme, notion }: WidgetContainerProp
     <div style={{
       width: '100%',
       height: '100%',
-      aspectRatio: `${aspectRatio}`,
+      // Only apply aspectRatio when embedded to allow Notion to control the size
+      // When standalone, parent container defines the size via defaultSize
+      ...(isEmbedded && { aspectRatio: `${aspectRatio}` }),
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',

--- a/components/widgets/YearProgress.tsx
+++ b/components/widgets/YearProgress.tsx
@@ -52,9 +52,9 @@ export function YearProgress({ theme, locale = 'en', notion }: YearProgressProps
     <WidgetContainer theme={theme} notion={notion}>
       <div style={{
         width: '100%',
-        maxWidth: '400px',
+        maxWidth: '100%',
         margin: '0 auto',
-        padding: '24px',
+        padding: '8px',
         textAlign: 'center',
       }}>
         {/* Year title */}


### PR DESCRIPTION
Fixed multiple issues with widget sizing to ensure proper display both in Notion embeds and standalone web views:

**WidgetDisplay.tsx**
- Add iframe detection to differentiate between Notion embed and standalone modes
- Apply defaultSize (from widgets.ts) in standalone mode for proper web display
- Use 100% dimensions in embed mode to fit Notion iframe constraints

**WidgetContainer.tsx**
- Apply aspectRatio only when embedded to allow Notion to control sizing
- In standalone mode, let parent container define size via defaultSize
- Ensures proper responsive behavior in both contexts

**Widget Components (Calendar, YearProgress, Countdown, Quote)**
- Remove hardcoded maxWidth constraints (400px, 500px, 600px)
- Change to maxWidth: 100% for proper responsive behavior
- Reduce padding to avoid content overflow in smaller sizes
- Allow widgets to adapt to their container size appropriately

These changes ensure widgets display correctly:
- In Notion: Respect embed iframe dimensions and aspect ratios
- On Web: Display at intended defaultSize with proper proportions
- Both contexts: Maintain responsive design and proper content layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)